### PR TITLE
Update device.py

### DIFF
--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,5 +1,5 @@
 """The device class used by SkybellPy."""
-import distutils
+import distutils.util
 import json
 import logging
 


### PR DESCRIPTION
Changes "import distutils" to "import distutils.util" to overcome error below in python 3.5

 File "<mypath>/skybellpy/device.py", line 206, in do_not_disturb
    return bool(distutils.util.strtobool(str(self._settings_json.get(
AttributeError: module 'distutils' has no attribute 'util'

Discussed at https://github.com/home-assistant/home-assistant/issues/13133