### PR TITLE
Fix Do Not Disturb on Python 3.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - python: "3.5"
       env: TOXENV=build
     - python: "3.5"
-      env: TOXENV=pylint
+      env: TOXENV=lint
 
 install: pip install -U tox coveralls
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ matrix:
   include:
     - python: "3.4.2"
       env: TOXENV=py34
+    - python: "3.4.2"
+      env: TOXENV=lint
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.6-dev"
       env: TOXENV=py36
-    - python: "3.5"
+    - python: "3.4.2"
       env: TOXENV=build
-    - python: "3.5"
-      env: TOXENV=lint
 
-install: pip install -U tox coveralls pylint==1.7.5
+install: pip install -U tox coveralls
 language: python
 script: tox
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "3.5"
       env: TOXENV=lint
 
-install: pip install -U tox coveralls
+install: pip install -U tox coveralls pylint==1.7.5
 language: python
 script: tox
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ matrix:
   include:
     - python: "3.4.2"
       env: TOXENV=py34
-    - python: "3.4.2"
-      env: TOXENV=lint
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.6-dev"
       env: TOXENV=py36
-    - python: "3.4.2"
+    - python: "3.5"
       env: TOXENV=build
+    - python: "3.5"
+      env: TOXENV=pylint
 
 install: pip install -U tox coveralls
 language: python

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,12 +1,7 @@
 """The device class used by SkybellPy."""
+import distutils.utils # pylint: disable=import-error
 import json
 import logging
-
-try:
-    import distutils
-    import distutils.utils
-except ImportError:
-    pass
 
 from skybellpy.exceptions import SkybellException
 import skybellpy.helpers.constants as CONST

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,6 +1,5 @@
 """The device class used by SkybellPy."""
 import distutils
-from distutils import utils  # pylint: disable=import-error
 import json
 import logging
 
@@ -204,8 +203,17 @@ class SkybellDevice(object):
     @property
     def do_not_disturb(self):
         """Get if do not disturb is enabled."""
-        return bool(distutils.util.strtobool(str(self._settings_json.get(
-            CONST.SETTINGS_DO_NOT_DISTURB))))
+        def strtobool(s):
+            if s is True or s is False:
+                return s
+            try:
+                s = str(s).strip().lower()[0]
+            except IndexError:
+                s = ""
+            return not s in ['f', 'n', '0', '']
+
+        return strtobool(self._settings_json.get(
+            CONST.SETTINGS_DO_NOT_DISTURB))
 
     @do_not_disturb.setter
     def do_not_disturb(self, enabled):

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,7 +1,12 @@
 """The device class used by SkybellPy."""
-import distutils.utils
+import distutils
 import json
 import logging
+
+try:
+    import distutils.utils
+except ImportError:
+    pass
 
 from skybellpy.exceptions import SkybellException
 import skybellpy.helpers.constants as CONST

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,5 +1,5 @@
 """The device class used by SkybellPy."""
-import distutils.utils # pylint: disable=import-error
+import distutils.utils  # pylint: disable=import-error
 import json
 import logging
 

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,5 +1,6 @@
 """The device class used by SkybellPy."""
-import distutils.utils  # pylint: disable=no-name-in-module,import-error
+import distutils
+from distutils import utils  # pylint: disable=import-error
 import json
 import logging
 

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,4 +1,5 @@
 """The device class used by SkybellPy."""
+import distutils
 from distutils import utils
 import json
 import logging

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,16 +1,17 @@
 """The device class used by SkybellPy."""
 import json
 import logging
-
-try:
-    import distutils.utils
-except ImportError:
-    import distutils
+import distutils
 
 from skybellpy.exceptions import SkybellException
 import skybellpy.helpers.constants as CONST
 import skybellpy.helpers.errors as ERROR
 import skybellpy.utils as UTILS
+
+try:
+    from distutils import utils
+except ImportError:
+    pass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,5 +1,5 @@
 """The device class used by SkybellPy."""
-import distutils.utils  # pylint: disable=import-error
+import distutils.utils  # pylint: disable=no-name-in-module,import-error
 import json
 import logging
 

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,5 +1,4 @@
 """The device class used by SkybellPy."""
-import distutils
 import json
 import logging
 
@@ -210,7 +209,7 @@ class SkybellDevice(object):
                 s = str(s).strip().lower()[0]
             except IndexError:
                 s = ""
-            return not s in ['f', 'n', '0', '']
+            return s not in ['f', 'n', '0', '']
 
         return strtobool(self._settings_json.get(
             CONST.SETTINGS_DO_NOT_DISTURB))

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,8 +1,11 @@
 """The device class used by SkybellPy."""
-import distutils
-from distutils import utils
 import json
 import logging
+
+try:
+  import distutils.utils
+except ImportError:
+  import distutils
 
 from skybellpy.exceptions import SkybellException
 import skybellpy.helpers.constants as CONST

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,5 +1,5 @@
 """The device class used by SkybellPy."""
-import distutils
+from distutils import utils
 import json
 import logging
 

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -202,14 +202,15 @@ class SkybellDevice(object):
     @property
     def do_not_disturb(self):
         """Get if do not disturb is enabled."""
-        def strtobool(s):
-            if s is True or s is False:
-                return s
+        def strtobool(value):
+            """Convert a variable to a boolean value."""
+            if value is True or value is False:
+                return value
             try:
-                s = str(s).strip().lower()[0]
+                value = str(value).strip().lower()[0]
             except IndexError:
-                s = ""
-            return s not in ['f', 'n', '0', '']
+                value = ""
+            return value not in ['f', 'n', '0', '']
 
         return strtobool(self._settings_json.get(
             CONST.SETTINGS_DO_NOT_DISTURB))

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,8 +1,8 @@
 """The device class used by SkybellPy."""
-import distutils
 import json
 import logging
 
+import distutils
 try:
     import distutils.utils
 except ImportError:

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -1,17 +1,12 @@
 """The device class used by SkybellPy."""
+import distutils.utils
 import json
 import logging
-import distutils
 
 from skybellpy.exceptions import SkybellException
 import skybellpy.helpers.constants as CONST
 import skybellpy.helpers.errors as ERROR
 import skybellpy.utils as UTILS
-
-try:
-    from distutils import utils
-except ImportError:
-    pass
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -3,9 +3,9 @@ import json
 import logging
 
 try:
-  import distutils.utils
+    import distutils.utils
 except ImportError:
-  import distutils
+    import distutils
 
 from skybellpy.exceptions import SkybellException
 import skybellpy.helpers.constants as CONST

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -2,8 +2,8 @@
 import json
 import logging
 
-import distutils
 try:
+    import distutils
     import distutils.utils
 except ImportError:
     pass

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -227,14 +227,15 @@ class TestSkybell(unittest.TestCase):
     @requests_mock.mock()
     def tests_settings_change(self, m):
         """Check that the Skybell device changes data."""
-        def strtobool(s):
-            if s is True or s is False:
-                return s
+        def strtobool(value):
+            """Convert a variable to a boolean value."""
+            if value is True or value is False:
+                return value
             try:
-                s = str(s).strip().lower()[0]
+                value = str(value).strip().lower()[0]
             except IndexError:
-                s = ""
-            return s not in ['f', 'n', '0', '']
+                value = ""
+            return value not in ['f', 'n', '0', '']
 
         m.post(CONST.LOGIN_URL, text=LOGIN.post_response_ok())
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,7 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
-import distutils
+import distutils.utils
 import json
 import unittest
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -5,9 +5,13 @@ Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
 import distutils
-from distutils import utils
 import json
 import unittest
+
+try:
+    import distutils.utils
+except ImportError:
+    pass
 
 import requests_mock
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,14 +4,9 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
+import distutils.utils # pylint: disable=import-error
 import json
 import unittest
-
-try:
-    import distutils
-    import distutils.utils
-except ImportError:
-    pass
 
 import requests_mock
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,10 +4,10 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
-import distutils
-from distutils import utils  # pylint: disable=import-error
 import json
 import unittest
+
+from distutils import utils as ut
 
 import requests_mock
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,7 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
-import distutils.utils  # pylint: disable=import-error
+import distutils.utils  # pylint: disable=no-name-in-module,import-error
 import json
 import unittest
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,8 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
-import distutils.utils
+import distutils
+from distutils import utils
 import json
 import unittest
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -234,7 +234,7 @@ class TestSkybell(unittest.TestCase):
                 s = str(s).strip().lower()[0]
             except IndexError:
                 s = ""
-            return not s in ['f', 'n', '0', '']
+            return s not in ['f', 'n', '0', '']
 
         m.post(CONST.LOGIN_URL, text=LOGIN.post_response_ok())
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -7,8 +7,6 @@ import datetime
 import json
 import unittest
 
-from distutils import utils as ut
-
 import requests_mock
 
 import skybellpy
@@ -229,6 +227,15 @@ class TestSkybell(unittest.TestCase):
     @requests_mock.mock()
     def tests_settings_change(self, m):
         """Check that the Skybell device changes data."""
+        def strtobool(s):
+            if s is True or s is False:
+                return s
+            try:
+                s = str(s).strip().lower()[0]
+            except IndexError:
+                s = ""
+            return not s in ['f', 'n', '0', '']
+
         m.post(CONST.LOGIN_URL, text=LOGIN.post_response_ok())
 
         # Set up device
@@ -260,7 +267,7 @@ class TestSkybell(unittest.TestCase):
         for value in CONST.SETTINGS_DO_NOT_DISTURB_VALUES:
             device.do_not_disturb = value
             self.assertEqual(device.do_not_disturb,
-                             distutils.util.strtobool(value))
+                             strtobool(value))
 
         for value in CONST.SETTINGS_OUTDOOR_CHIME_VALUES:
             device.outdoor_chime_level = value

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,8 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
-import distutils.utils  # pylint: disable=no-name-in-module,import-error
+import distutils
+from distutils import utils  # pylint: disable=import-error
 import json
 import unittest
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,7 +4,7 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
-import distutils.utils # pylint: disable=import-error
+import distutils.utils  # pylint: disable=import-error
 import json
 import unittest
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -7,8 +7,8 @@ import datetime
 import json
 import unittest
 
-import distutils
 try:
+    import distutils
     import distutils.utils
 except ImportError:
     pass

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,10 +4,10 @@ Test Skybell device functionality.
 Tests the device initialization and attributes of the Skybell device class.
 """
 import datetime
-import distutils
 import json
 import unittest
 
+import distutils
 try:
     import distutils.utils
 except ImportError:


### PR DESCRIPTION
An attempt to fix Do Not Disturb on all Python 3.x versions. `import distutils.utils` failed Travis CI build for 3.4.2.