### PR TITLE
Switch from avatar url to last activity url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Changelog
 
 A list of changes between each release.
 
+0.2.0 (2018-12-07)
+^^^^^^^^^^^^^^^^^^
+- Swtich device image from avatar url (broken) to last activity image.
+
 0.1.0 (2017-09-24)
 ^^^^^^^^^^^^^^^^^^
 - Initial release of skybellpy

--- a/skybellpy/__init__.py
+++ b/skybellpy/__init__.py
@@ -179,9 +179,12 @@ class Skybell():
         headers['x-skybell-app-id'] = self.cache(CONST.APP_ID)
         headers['x-skybell-client-id'] = self.cache(CONST.CLIENT_ID)
 
+        _LOGGER.debug("HTTP %s %s Request with headers: %s", method, url, headers)
+
         try:
             response = getattr(self._session, method)(
                 url, headers=headers, json=json_data)
+            _LOGGER.debug("%s %s", response, response.text)
 
             if response and response.status_code < 400:
                 return response

--- a/skybellpy/__init__.py
+++ b/skybellpy/__init__.py
@@ -179,7 +179,8 @@ class Skybell():
         headers['x-skybell-app-id'] = self.cache(CONST.APP_ID)
         headers['x-skybell-client-id'] = self.cache(CONST.CLIENT_ID)
 
-        _LOGGER.debug("HTTP %s %s Request with headers: %s", method, url, headers)
+        _LOGGER.debug("HTTP %s %s Request with headers: %s",
+                      method, url, headers)
 
         try:
             response = getattr(self._session, method)(

--- a/skybellpy/__main__.py
+++ b/skybellpy/__main__.py
@@ -15,6 +15,7 @@ import logging
 import argparse
 
 import skybellpy
+import skybellpy.helpers.constants as CONST
 from skybellpy.exceptions import SkybellException
 
 _LOGGER = logging.getLogger('skybellcl')
@@ -92,15 +93,27 @@ def get_arguments():
         required=False, action='append')
 
     parser.add_argument(
+        '--last-json',
+        metavar='device_id',
+        help='Output the last activity json for device_id',
+        required=False, action='append')
+
+    parser.add_argument(
+        '--last-image',
+        metavar='device_id',
+        help='Output the last activity image url for device_id',
+        required=False, action='append')
+
+    parser.add_argument(
         '--capture',
         metavar='device_id',
-        help='Trigger a new image capture for the given device_id',
+        help='NOT IMPLEMENTED Trigger a new image capture for the given device_id',
         required=False, action='append')
 
     parser.add_argument(
         '--image',
         metavar='device_id=location/image.jpg',
-        help='Save an image from a camera (if available) to the given path',
+        help='NOT IMPLEMENTED Save an image from a camera (if available) to the given path',
         required=False, action='append')
 
     parser.add_argument(
@@ -133,7 +146,7 @@ def call():
     skybell = None
 
     try:
-        # Create abodepy instance.
+        # Create skybellpy instance.
         skybell = skybellpy.Skybell(username=args.username,
                                     password=args.password,
                                     get_devices=True)
@@ -151,7 +164,7 @@ def call():
             if device:
                 # pylint: disable=protected-access
                 _LOGGER.info(device_id + " JSON:\n" +
-                             json.dumps(device._json_state, sort_keys=True,
+                             json.dumps(device._device_json, sort_keys=True,
                                         indent=4, separators=(',', ': ')))
             else:
                 _LOGGER.warning("Could not find device with id: %s", device_id)
@@ -173,6 +186,28 @@ def call():
 
                 if device:
                     _device_print(device)
+                else:
+                    _LOGGER.warning(
+                        "Could not find device with id: %s", device_id)
+
+        # Print out last motion event
+        if args.last_json:
+            for device_id in args.last_json:
+                device = skybell.get_device(device_id)
+
+                if device:
+                    _LOGGER.info(device.latest(CONST.EVENT_MOTION))
+                else:
+                    _LOGGER.warning(
+                        "Could not find device with id: %s", device_id)
+
+        # Print out last motion event
+        if args.last_image:
+            for device_id in args.last_image:
+                device = skybell.get_device(device_id)
+
+                if device:
+                    _LOGGER.info(device.image)
                 else:
                     _LOGGER.warning(
                         "Could not find device with id: %s", device_id)

--- a/skybellpy/__main__.py
+++ b/skybellpy/__main__.py
@@ -107,13 +107,15 @@ def get_arguments():
     parser.add_argument(
         '--capture',
         metavar='device_id',
-        help='NOT IMPLEMENTED Trigger a new image capture for the given device_id',
+        help='NOT IMPLEMENTED: '
+             'Trigger a new image capture for the given device_id',
         required=False, action='append')
 
     parser.add_argument(
         '--image',
         metavar='device_id=location/image.jpg',
-        help='NOT IMPLEMENTED Save an image from a camera (if available) to the given path',
+        help='NOT IMPLEMENTED: '
+             'Save an image from a camera (if available) to the given path',
         required=False, action='append')
 
     parser.add_argument(

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -129,11 +129,19 @@ class SkybellDevice(object):
         # Return the requested number
         return activities[:limit]
 
-    def latest(self, event):
+    def latest(self, event=None):
         """Return the latest event activity."""
         events = self._skybell.dev_cache(self, CONST.EVENT) or {}
+        _LOGGER.debug(events)
         # self._skybell._cache)
-        return events.get(event)
+        if event:
+            return events.get(event)
+        else:
+            latest = None
+            for type, evt in events.items():
+                if not latest or latest.get(CONST.CREATED_AT) < evt.get(CONST.CREATED_AT):
+                    latest = evt
+            return latest
 
     def _set_setting(self, settings):
         """Validate the settings and then send the PATCH request."""
@@ -184,7 +192,9 @@ class SkybellDevice(object):
     @property
     def image(self):
         """Get the most recent 'avatar' image."""
-        return self._device_json.get(CONST.AVATAR, {}).get(CONST.AVATAR_URL)
+        # avatar AWS url stopped working October 2018, switched to last activity url
+        #return self._device_json.get(CONST.AVATAR, {}).get(CONST.AVATAR_URL)
+        return self.latest().get(CONST.MEDIA_URL)
 
     @property
     def wifi_status(self):

--- a/skybellpy/device.py
+++ b/skybellpy/device.py
@@ -133,15 +133,16 @@ class SkybellDevice(object):
         """Return the latest event activity."""
         events = self._skybell.dev_cache(self, CONST.EVENT) or {}
         _LOGGER.debug(events)
-        # self._skybell._cache)
+
         if event:
             return events.get(event)
-        else:
-            latest = None
-            for type, evt in events.items():
-                if not latest or latest.get(CONST.CREATED_AT) < evt.get(CONST.CREATED_AT):
-                    latest = evt
-            return latest
+
+        latest = None
+        for _, evt in events.items():
+            if not latest or \
+                    latest.get(CONST.CREATED_AT) < evt.get(CONST.CREATED_AT):
+                latest = evt
+        return latest
 
     def _set_setting(self, settings):
         """Validate the settings and then send the PATCH request."""
@@ -192,8 +193,9 @@ class SkybellDevice(object):
     @property
     def image(self):
         """Get the most recent 'avatar' image."""
-        # avatar AWS url stopped working October 2018, switched to last activity url
-        #return self._device_json.get(CONST.AVATAR, {}).get(CONST.AVATAR_URL)
+        # avatar AWS url stopped working October 2018
+        # switched to last activity url
+        # return self._device_json.get(CONST.AVATAR, {}).get(CONST.AVATAR_URL)
         return self.latest().get(CONST.MEDIA_URL)
 
     @property

--- a/skybellpy/helpers/constants.py
+++ b/skybellpy/helpers/constants.py
@@ -2,8 +2,8 @@
 import os
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 1
-PATCH_VERSION = '2'
+MINOR_VERSION = 2
+PATCH_VERSION = '0'
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 

--- a/skybellpy/helpers/constants.py
+++ b/skybellpy/helpers/constants.py
@@ -42,6 +42,7 @@ CACHE_PATH = './skybell.pickle'
 
 # URLS
 BASE_URL = 'https://cloud.myskybell.com/api/v3/'
+BASE_URL_V4 = 'https://cloud.myskybell.com/api/v4/'
 
 LOGIN_URL = BASE_URL + 'login/'
 LOGOUT_URL = BASE_URL + 'logout/'
@@ -55,8 +56,8 @@ DEVICE_AVATAR_URL = DEVICE_URL + 'avatar/'
 DEVICE_INFO_URL = DEVICE_URL + 'info/'
 DEVICE_SETTINGS_URL = DEVICE_URL + 'settings/'
 
-SUBSCRIPTIONS_URL = BASE_URL + 'subscriptions/?include=owner'
-SUBSCRIPTION_URL = BASE_URL + 'subscriptions/$SUBSCRIPTIONID$/'
+SUBSCRIPTIONS_URL = BASE_URL + 'subscriptions?include=device,owner'
+SUBSCRIPTION_URL = BASE_URL + 'subscriptions/$SUBSCRIPTIONID$'
 SUBSCRIPTION_INFO_URL = SUBSCRIPTION_URL + '/info/'
 SUBSCRIPTION_SETTINGS_URL = SUBSCRIPTION_URL + '/settings/'
 
@@ -78,6 +79,7 @@ LOCATION_LAT = 'lat'
 LOCATION_LNG = 'lng'
 AVATAR = 'avatar'
 AVATAR_URL = 'url'
+MEDIA_URL = 'media'
 
 # DEVICE INFO
 WIFI_LINK = 'wifiLink'

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -56,13 +56,21 @@ class TestSkybell(unittest.TestCase):
         settings_url = str.replace(CONST.DEVICE_SETTINGS_URL,
                                    '$DEVID$', DEVICE.DEVID)
 
+        activities_text = '[' + \
+                          DEVICE_ACTIVITIES.get_response_ok(
+                              dev_id=DEVICE.DEVID,
+                              event=CONST.EVENT_BUTTON) + ',' + \
+                          DEVICE_ACTIVITIES.get_response_ok(
+                              dev_id=DEVICE.DEVID,
+                              event=CONST.EVENT_MOTION) + ']'
+        activities_json = json.loads(activities_text)
         activities_url = str.replace(CONST.DEVICE_ACTIVITIES_URL,
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
-        m.get(activities_url, text=DEVICE_ACTIVITIES.EMPTY_ACTIVITIES_RESPONSE)
+        m.get(activities_url, text=activities_text)
 
         # Logout to reset everything
         self.skybell.logout()
@@ -84,8 +92,11 @@ class TestSkybell(unittest.TestCase):
                          device_json[0][CONST.LOCATION][CONST.LOCATION_LAT])
         self.assertEqual(device.location[1],
                          device_json[0][CONST.LOCATION][CONST.LOCATION_LNG])
+        # device image replaced with last activity
+        # self.assertEqual(device.image,
+        #                  device_json[0][CONST.AVATAR][CONST.AVATAR_URL])
         self.assertEqual(device.image,
-                         device_json[0][CONST.AVATAR][CONST.AVATAR_URL])
+                         activities_json[0][CONST.MEDIA_URL])
 
         # Test Info Details
         self.assertEqual(device.wifi_status,


### PR DESCRIPTION
Sometime in October avatar url which was being used for the camera image stopped working. The current next best option is to switch to using the last activity's media url.
Hopefully, I will get a response about Skybell Connect and we can do a real implementation.