### PR TITLE
Fix avatar image url, add ability to continue to get last activity image url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ ENV/
 /.pydevproject
 .settings/
 *.pickle
+
+# pycharm IDE settings
+.idea/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,9 +3,14 @@ Changelog
 
 A list of changes between each release.
 
+0.3.0 (2018-12-14)
+^^^^^^^^^^^^^^^^^^
+- Switch device image back to avatar url (fixed)
+- Preserve last activity image functionality via `device.activity_image`
+
 0.2.0 (2018-12-07)
 ^^^^^^^^^^^^^^^^^^
-- Swtich device image from avatar url (broken) to last activity image.
+- Switch device image from avatar url (broken) to last activity image.
 
 0.1.0 (2017-09-24)
 ^^^^^^^^^^^^^^^^^^

--- a/skybell.http
+++ b/skybell.http
@@ -209,6 +209,17 @@ authorization: {{access_token}}
 
 ###
 
+// Get avatar url for a single device
+
+GET https://cloud.myskybell.com/api/v3/devices/{{device_id}}/avatar HTTP/1.1
+content-type: application/json
+user-agent: SkyBell/3.4.1 (iPhone9,2; iOS 11.0; loc=en_US; lang=en-US) com.skybell.doorbell/1
+x-skybell-app-id: {{app_id}}
+x-skybell-client-id: {{client_id}}
+authorization: {{access_token}}
+
+###
+
 // Get activities for a single device
 
 GET https://cloud.myskybell.com/api/v3/devices/{{device_id}}/activities HTTP/1.1

--- a/skybellpy/__main__.py
+++ b/skybellpy/__main__.py
@@ -93,13 +93,19 @@ def get_arguments():
         required=False, action='append')
 
     parser.add_argument(
-        '--last-json',
+        '--activity-json',
         metavar='device_id',
-        help='Output the last activity json for device_id',
+        help='Output the activity activity json for device_id',
         required=False, action='append')
 
     parser.add_argument(
-        '--last-image',
+        '--avatar-image',
+        metavar='device_id',
+        help='Output the avatar image url for device_id',
+        required=False, action='append')
+
+    parser.add_argument(
+        '--activity-image',
         metavar='device_id',
         help='Output the last activity image url for device_id',
         required=False, action='append')
@@ -193,8 +199,8 @@ def call():
                         "Could not find device with id: %s", device_id)
 
         # Print out last motion event
-        if args.last_json:
-            for device_id in args.last_json:
+        if args.activity_json:
+            for device_id in args.activity_json:
                 device = skybell.get_device(device_id)
 
                 if device:
@@ -203,13 +209,24 @@ def call():
                     _LOGGER.warning(
                         "Could not find device with id: %s", device_id)
 
-        # Print out last motion event
-        if args.last_image:
-            for device_id in args.last_image:
+        # Print out avatar image
+        if args.avatar_image:
+            for device_id in args.avatar_image:
                 device = skybell.get_device(device_id)
 
                 if device:
                     _LOGGER.info(device.image)
+                else:
+                    _LOGGER.warning(
+                        "Could not find device with id: %s", device_id)
+
+        # Print out last motion event image
+        if args.activity_image:
+            for device_id in args.activity_image:
+                device = skybell.get_device(device_id)
+
+                if device:
+                    _LOGGER.info(device.activity_image)
                 else:
                     _LOGGER.warning(
                         "Could not find device with id: %s", device_id)

--- a/skybellpy/helpers/constants.py
+++ b/skybellpy/helpers/constants.py
@@ -2,7 +2,7 @@
 import os
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 2
+MINOR_VERSION = 3
 PATCH_VERSION = '0'
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)

--- a/tests/mock/device_avatar.py
+++ b/tests/mock/device_avatar.py
@@ -1,0 +1,12 @@
+"""Mock Skybell Device Avatar Response."""
+
+
+def get_response_ok(data=''):
+    """Return the successful device info response json."""
+    return '''
+    {
+      "createdAt": "2018-12-14T21:20:06.198Z",
+      "url":
+      "https://v3-production-devices-avatar.s3-us-west-2.amazonaws.com/''' + \
+           data + '''"
+    }'''

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,6 +16,7 @@ import skybellpy.helpers.constants as CONST
 
 import tests.mock.login as LOGIN
 import tests.mock.device as DEVICE
+import tests.mock.device_avatar as DEVICE_AVATAR
 import tests.mock.device_info as DEVICE_INFO
 import tests.mock.device_settings as DEVICE_SETTINGS
 import tests.mock.device_activities as DEVICE_ACTIVITIES
@@ -46,6 +47,11 @@ class TestSkybell(unittest.TestCase):
         device_text = '[' + DEVICE.get_response_ok() + ']'
         device_json = json.loads(device_text)
 
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_json = json.loads(avatar_text)
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_json = json.loads(info_text)
         info_url = str.replace(CONST.DEVICE_INFO_URL,
@@ -68,6 +74,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=activities_text)
@@ -92,10 +99,9 @@ class TestSkybell(unittest.TestCase):
                          device_json[0][CONST.LOCATION][CONST.LOCATION_LAT])
         self.assertEqual(device.location[1],
                          device_json[0][CONST.LOCATION][CONST.LOCATION_LNG])
-        # device image replaced with last activity
-        # self.assertEqual(device.image,
-        #                  device_json[0][CONST.AVATAR][CONST.AVATAR_URL])
         self.assertEqual(device.image,
+                         avatar_json[CONST.AVATAR_URL])
+        self.assertEqual(device.activity_image,
                          activities_json[0][CONST.MEDIA_URL])
 
         # Test Info Details
@@ -135,6 +141,10 @@ class TestSkybell(unittest.TestCase):
         device_name = 'Shut The Back Door'
         device_text = '[' + DEVICE.get_response_ok(name=device_name) + ']'
 
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         device_ssid = 'Super SSID64'
         device_wifi_status = 'good'
         info_text = DEVICE_INFO.get_response_ok(
@@ -163,6 +173,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=DEVICE_ACTIVITIES.EMPTY_ACTIVITIES_RESPONSE)
@@ -193,6 +204,10 @@ class TestSkybell(unittest.TestCase):
         device_text = DEVICE.get_response_ok(name=device_name)
         device_url = str.replace(CONST.DEVICE_URL, '$DEVID$', DEVICE.DEVID)
 
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         device_ssid = 'Gamecube'
         device_wifi_status = 'bad'
         info_text = DEVICE_INFO.get_response_ok(
@@ -215,6 +230,7 @@ class TestSkybell(unittest.TestCase):
             led_intensity)
 
         m.get(device_url, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
 
@@ -244,6 +260,11 @@ class TestSkybell(unittest.TestCase):
 
         # Set up device
         device_text = '[' + DEVICE.get_response_ok() + ']'
+
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_url = str.replace(CONST.DEVICE_INFO_URL, '$DEVID$', DEVICE.DEVID)
 
@@ -254,6 +275,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=DEVICE_ACTIVITIES.EMPTY_ACTIVITIES_RESPONSE)
@@ -304,6 +326,11 @@ class TestSkybell(unittest.TestCase):
 
         # Set up device
         device_text = '[' + DEVICE.get_response_ok() + ']'
+
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_url = str.replace(CONST.DEVICE_INFO_URL, '$DEVID$', DEVICE.DEVID)
 
@@ -314,6 +341,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=DEVICE_ACTIVITIES.EMPTY_ACTIVITIES_RESPONSE)
@@ -378,6 +406,11 @@ class TestSkybell(unittest.TestCase):
 
         # Set up device
         device_text = '[' + DEVICE.get_response_ok() + ']'
+
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_url = str.replace(CONST.DEVICE_INFO_URL, '$DEVID$', DEVICE.DEVID)
 
@@ -389,6 +422,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=DEVICE_ACTIVITIES.EMPTY_ACTIVITIES_RESPONSE)
@@ -414,6 +448,11 @@ class TestSkybell(unittest.TestCase):
 
         # Set up device
         device_text = '[' + DEVICE.get_response_ok() + ']'
+
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_url = str.replace(CONST.DEVICE_INFO_URL, '$DEVID$', DEVICE.DEVID)
 
@@ -422,21 +461,22 @@ class TestSkybell(unittest.TestCase):
                                    '$DEVID$', DEVICE.DEVID)
 
         activities_text = '[' + \
-            DEVICE_ACTIVITIES.get_response_ok(
-                dev_id=DEVICE.DEVID,
-                event=CONST.EVENT_BUTTON) + ',' + \
-            DEVICE_ACTIVITIES.get_response_ok(
-                dev_id=DEVICE.DEVID,
-                event=CONST.EVENT_MOTION) + ',' + \
-            DEVICE_ACTIVITIES.get_response_ok(
-                dev_id=DEVICE.DEVID,
-                event=CONST.EVENT_ON_DEMAND) + ']'
+                          DEVICE_ACTIVITIES.get_response_ok(
+                              dev_id=DEVICE.DEVID,
+                              event=CONST.EVENT_BUTTON) + ',' + \
+                          DEVICE_ACTIVITIES.get_response_ok(
+                              dev_id=DEVICE.DEVID,
+                              event=CONST.EVENT_MOTION) + ',' + \
+                          DEVICE_ACTIVITIES.get_response_ok(
+                              dev_id=DEVICE.DEVID,
+                              event=CONST.EVENT_ON_DEMAND) + ']'
         activities_json = json.loads(activities_text)
 
         activities_url = str.replace(CONST.DEVICE_ACTIVITIES_URL,
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=activities_text)
@@ -468,6 +508,11 @@ class TestSkybell(unittest.TestCase):
 
         # Set up device
         device_text = '[' + DEVICE.get_response_ok() + ']'
+
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_url = str.replace(CONST.DEVICE_INFO_URL, '$DEVID$', DEVICE.DEVID)
 
@@ -483,6 +528,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=activities_text)
@@ -515,6 +561,11 @@ class TestSkybell(unittest.TestCase):
 
         # Set up device
         device_text = '[' + DEVICE.get_response_ok() + ']'
+
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_url = str.replace(CONST.DEVICE_INFO_URL, '$DEVID$', DEVICE.DEVID)
 
@@ -540,6 +591,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)
         m.get(activities_url, text=activities_text)
@@ -568,6 +620,10 @@ class TestSkybell(unittest.TestCase):
         device_text = '[' + device + ']'
         device_url = str.replace(CONST.DEVICE_URL, '$DEVID$', DEVICE.DEVID)
 
+        avatar_text = DEVICE_AVATAR.get_response_ok()
+        avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                 '$DEVID$', DEVICE.DEVID)
+
         info_text = DEVICE_INFO.get_response_ok()
         info_url = str.replace(CONST.DEVICE_INFO_URL, '$DEVID$', DEVICE.DEVID)
 
@@ -585,6 +641,7 @@ class TestSkybell(unittest.TestCase):
                                      '$DEVID$', DEVICE.DEVID)
 
         m.get(CONST.DEVICES_URL, text=device_text)
+        m.get(avatar_url, text=avatar_text)
         m.get(device_url, text=device)
         m.get(info_url, text=info_text)
         m.get(settings_url, text=settings_text)

--- a/tests/test_skybell.py
+++ b/tests/test_skybell.py
@@ -16,6 +16,7 @@ import skybellpy.helpers.constants as CONST
 import tests.mock as MOCK
 import tests.mock.login as LOGIN
 import tests.mock.device as DEVICE
+import tests.mock.device_avatar as DEVICE_AVATAR
 import tests.mock.device_info as DEVICE_INFO
 import tests.mock.device_settings as DEVICE_SETTINGS
 import tests.mock.device_activities as DEVICE_ACTIVITIES
@@ -282,6 +283,9 @@ class TestSkybell(unittest.TestCase):
         """Check that device retrieval works."""
         dev1_devid = 'dev1'
         dev1 = DEVICE.get_response_ok(name='Dev1', dev_id=dev1_devid)
+        dev1_avatar = DEVICE_AVATAR.get_response_ok('dev1')
+        dev1_avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                      '$DEVID$', dev1_devid)
         dev1_info = DEVICE_INFO.get_response_ok(dev_id=dev1_devid)
         dev1_info_url = str.replace(CONST.DEVICE_INFO_URL,
                                     '$DEVID$', dev1_devid)
@@ -293,6 +297,9 @@ class TestSkybell(unittest.TestCase):
 
         dev2_devid = 'dev2'
         dev2 = DEVICE.get_response_ok(name='Dev2', dev_id=dev2_devid)
+        dev2_avatar = DEVICE_AVATAR.get_response_ok('dev2')
+        dev2_avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                      '$DEVID$', dev2_devid)
         dev2_info = DEVICE_INFO.get_response_ok(dev_id=dev1_devid)
         dev2_info_url = str.replace(CONST.DEVICE_INFO_URL,
                                     '$DEVID$', dev2_devid)
@@ -304,6 +311,8 @@ class TestSkybell(unittest.TestCase):
 
         m.post(CONST.LOGIN_URL, text=LOGIN.post_response_ok())
         m.get(CONST.DEVICES_URL, text='[' + dev1 + ',' + dev2 + ']')
+        m.get(dev1_avatar_url, text=dev1_avatar)
+        m.get(dev2_avatar_url, text=dev2_avatar)
         m.get(dev1_info_url, text=dev1_info)
         m.get(dev2_info_url, text=dev2_info)
         m.get(dev1_settings_url, text=dev1_settings)
@@ -325,6 +334,8 @@ class TestSkybell(unittest.TestCase):
         self.assertIsNotNone(dev2_dev)
         self.assertEqual(json.loads(dev1), dev1_dev._device_json)
         self.assertEqual(json.loads(dev2), dev2_dev._device_json)
+        self.assertEqual(json.loads(dev1_avatar), dev1_dev._avatar_json)
+        self.assertEqual(json.loads(dev2_avatar), dev2_dev._avatar_json)
         self.assertEqual(json.loads(dev1_info), dev1_dev._info_json)
         self.assertEqual(json.loads(dev2_info), dev2_dev._info_json)
         self.assertEqual(json.loads(dev1_settings),
@@ -337,6 +348,9 @@ class TestSkybell(unittest.TestCase):
         """Check that device refresh works and reuses the same objects."""
         dev1_devid = 'dev1'
         dev1a = DEVICE.get_response_ok(name='Dev1', dev_id=dev1_devid)
+        dev1a_avatar = DEVICE_AVATAR.get_response_ok('dev1a')
+        dev1a_avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                       '$DEVID$', dev1_devid)
         dev1a_info = DEVICE_INFO.get_response_ok(dev_id=dev1_devid)
         dev1a_info_url = str.replace(CONST.DEVICE_INFO_URL,
                                      '$DEVID$', dev1_devid)
@@ -349,6 +363,9 @@ class TestSkybell(unittest.TestCase):
 
         dev2_devid = 'dev2'
         dev2a = DEVICE.get_response_ok(name='Dev2', dev_id=dev2_devid)
+        dev2a_avatar = DEVICE_AVATAR.get_response_ok('dev2a')
+        dev2a_avatar_url = str.replace(CONST.DEVICE_AVATAR_URL,
+                                       '$DEVID$', dev2_devid)
         dev2a_info = DEVICE_INFO.get_response_ok(dev_id=dev1_devid)
         dev2a_info_url = str.replace(CONST.DEVICE_INFO_URL,
                                      '$DEVID$', dev2_devid)
@@ -361,6 +378,8 @@ class TestSkybell(unittest.TestCase):
 
         m.post(CONST.LOGIN_URL, text=LOGIN.post_response_ok())
         m.get(CONST.DEVICES_URL, text='[' + dev1a + ',' + dev2a + ']')
+        m.get(dev1a_avatar_url, text=dev1a_avatar)
+        m.get(dev2a_avatar_url, text=dev2a_avatar)
         m.get(dev1a_info_url, text=dev1a_info)
         m.get(dev2a_info_url, text=dev2a_info)
         m.get(dev1a_settings_url, text=dev1a_settings)


### PR DESCRIPTION
I was able to fix the avatar url (thanks @thoukydides) and restore that to the device.image property.
I exposed the last activity image url via device.activity_image.

I'm working on a HA change to add a config to skybell camera to support including the image of your choosing (or both). The default will be avatar image like it used to be.